### PR TITLE
Replace question marks with underscores

### DIFF
--- a/inc/front/process.php
+++ b/inc/front/process.php
@@ -207,6 +207,9 @@ if ( ! empty( $rocket_cache_dynamic_cookies ) ) {
 
 // Caching file path.
 $request_uri_path      = preg_replace_callback( '/%[0-9A-F]{2}/', 'rocket_urlencode_lowercase', $request_uri_path );
+// Directories in Windows can't contain question marks
+$request_uri_path = str_replace( '?', '_', $request_uri_path );
+
 $rocket_cache_filepath = $request_uri_path . '/' . $filename . '.html';
 
 // Serve the cache file if exist.


### PR DESCRIPTION
This makes query var caching work in Windows.